### PR TITLE
Fix project index page ID on delete form and button

### DIFF
--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -59,10 +59,10 @@
                                             </a>
                                         </td>
                                         <td class="align-middle">
-                                            <a onclick="event.preventDefault(); document.getElementById('delete-project-{{ $project->id }}').submit();" href="#" class="font-weight-bold text-xs btn btn-link text-danger text-gradient px-3 mb-0" data-toggle="tooltip" data-original-title="Edit user">
+                                            <a onclick="event.preventDefault(); document.getElementById('delete-project-{{ $project->id_project }}').submit();" href="#" class="font-weight-bold text-xs btn btn-link text-danger text-gradient px-3 mb-0" data-toggle="tooltip" data-original-title="Edit user">
                                                 Delete
                                             </a>
-                                            <form id="delete-project-{{ $project->id }}" action="{{ route('projects.destroy', $project) }}" method="POST" style="display: none;">
+                                            <form id="delete-project-{{ $project->id_project }}" action="{{ route('projects.destroy', $project) }}" method="POST" style="display: none;">
                                                 @csrf
                                                 @method('DELETE')
                                             </form>


### PR DESCRIPTION
## Hotfix: Corrigir ID da página de índice do projeto no formulário e botão de exclusão

### Problema
A página de índice do projeto apresenta um problema com o ID usado no formulário e no botão de exclusão. Atualmente, está sendo referenciado `{{ $project->id }}`, o que causa uma inconsistência e resulta em erros durante o processo de exclusão.

### Alterações Realizadas
Este hotfix soluciona o problema atualizando o código para utilizar `{{ $project->id_project }}` como o ID correto para o formulário e o botão de exclusão. Isso garante que a operação de exclusão seja realizada corretamente para cada projeto.

### Impacto
O ID incorreto estava impedindo os usuários de excluírem projetos com sucesso na página de índice. Com este hotfix, a funcionalidade de exclusão funcionará corretamente, permitindo que os usuários excluam projetos sem encontrar erros.

### Como Testar
Para testar este hotfix, siga as etapas abaixo:
1. Acesse a página de índice do projeto.
2. Verifique se o botão de exclusão é exibido corretamente para cada projeto.
3. Selecione um projeto e clique no botão de exclusão.
4. Confirme se o projeto é excluído sem erros ou problemas.

### Documentação Relacionada
Não são necessárias alterações específicas na documentação para este hotfix.


