### PR TITLE
fix: MySQL container memory leak on Fedora

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,11 @@ services:
             - "3306:3306"
         networks:
             - thoth
+        ulimits:
+            nproc: 65535
+            nofile:
+                soft: 20000
+                hard: 40000
     #phpmyadmin
     db-phpmyadmin:
         depends_on:


### PR DESCRIPTION
Resolve o problema que tenho enfrentando no meu desktop de alto uso de memória pelo container do MySQL no Fedora

Modelo usado como referencia:
https://gist.github.com/vicenterusso/ae6d6c903b790e5dae91c339c1ce2ba8